### PR TITLE
Get assets using the file paths from Markdown

### DIFF
--- a/TextBundle/TextBundleWrapper.swift
+++ b/TextBundle/TextBundleWrapper.swift
@@ -191,7 +191,20 @@ import CoreServices
     
     // MARK: - Assets
     
-    
+    @objc(assetFileWrapperForFilePath:) public func assetFileWrapper(filePath: String) -> FileWrapper? {
+        let pathComponents = (filePath as NSString).pathComponents
+
+        // Skip absolute paths even if they would point into the text bundle.
+        guard pathComponents.first != "/" else { return nil }
+        // Only permit 'assets/file.png' relative paths.
+        guard let filename = pathComponents.last,
+              case let pathComponentsToFile = pathComponents.dropLast(),
+              pathComponentsToFile.filter({ $0 != "." }) == ["assets"]
+        else { return nil }
+
+        return fileWrapper(for: filename)
+    }
+
     ///  Return the filewrapper represeting an asset or nil if there is no asset named with filename
     /// - Parameter assetFilename: A filename in the asset/ folder
     /// - Returns: A NSFilewrapper represeting filename or nil it the file doesn't exist

--- a/TextBundleTests/TextBundleTests.m
+++ b/TextBundleTests/TextBundleTests.m
@@ -175,6 +175,22 @@
     XCTAssertEqual(tb.assetsFileWrapper.fileWrappers.count, 3);
 }
 
+- (void)testAssetLookup
+{
+    NSURL *fileURL = [self textBundleURLForFilename:@"text plus attachments"];
+    NSError *e = nil;
+    TextBundleWrapper *tb = [[TextBundleWrapper alloc] initWithUrl:fileURL options:NSFileWrapperReadingImmediate error:&e];
+    XCTAssertNil(e);
+    XCTAssertEqual(tb.assetsFileWrapper.fileWrappers.count, 1);
+
+    XCTAssertNotNil([tb assetFileWrapperForFilePath:@"assets/oh no.jpg"]);
+    XCTAssertNotNil([tb assetFileWrapperForFilePath:@"./assets/oh no.jpg"]);
+    XCTAssertNil([tb assetFileWrapperForFilePath:@"oh no.jpg"], @"a path relative to the bundle is required");
+    XCTAssertNil([tb assetFileWrapperForFilePath:@"/tmp/bad/things/happen/oh no.jpg"], @"Non-existing path should not find the asset even though the filename matches");
+    XCTAssertNil([tb assetFileWrapperForFilePath:@"../sample asset.jpg"], @"Accessing files outside the bundle (relative to the bundle itself) should not work");
+    XCTAssertNil([tb assetFileWrapperForFilePath:@"../../sample asset.jpg"], @"Accessing files outside the bundle (relative to the ./asset/ subdir) should not work");
+}
+
 
 #pragma mark - Metadata
 


### PR DESCRIPTION
Adds `TextBundle.assetFileWrapper(filePath:)` as public API that can be used to get the `FileWrapper` directly based on `![](assets/foo.png)` file paths. 

Previously, users of the wrapper had to request the asset based on filename, but depending on the call site's naivety, would have resolved despicable paths like `/i/love/trump/ohno.png` to show the image at `assets/ohno.png`, which is not what we want.