### PR TITLE
Make asset-related function names similar

### DIFF
--- a/TextBundle/TextBundleWrapper.swift
+++ b/TextBundle/TextBundleWrapper.swift
@@ -191,8 +191,17 @@ import CoreServices
     
     // MARK: - Assets
     
-    @objc(assetFileWrapperForFilePath:) public func assetFileWrapper(filePath: String) -> FileWrapper? {
-        let pathComponents = (filePath as NSString).pathComponents
+    /// Returns the file wrapper for an asset at a bundle-relative path.
+    ///
+    /// The path must point into the `assets/` directory (e.g. `"assets/image.png"`
+    /// or `"./assets/image.png"`). Absolute paths and directory-traversal attempts
+    /// (e.g. `"../secret.txt"`) are rejected.
+    ///
+    /// - Parameter path: A bundle-relative path such as `"assets/photo.jpg"`.
+    /// - Returns: The matching ``FileWrapper``, or `nil` if the path is invalid
+    ///   or no asset with that filename exists.
+    @objc(assetFileWrapperAtPath:) public func assetFileWrapper(atPath path: String) -> FileWrapper? {
+        let pathComponents = (path as NSString).pathComponents
 
         // Skip absolute paths even if they would point into the text bundle.
         guard pathComponents.first != "/" else { return nil }
@@ -202,28 +211,45 @@ import CoreServices
               pathComponentsToFile.filter({ $0 != "." }) == ["assets"]
         else { return nil }
 
-        return fileWrapper(for: filename)
+        return self.assetFileWrapper(named: filename)
     }
 
-    ///  Return the filewrapper represeting an asset or nil if there is no asset named with filename
-    /// - Parameter assetFilename: A filename in the asset/ folder
-    /// - Returns: A NSFilewrapper represeting filename or nil it the file doesn't exist
-    @objc public func fileWrapper(for assetFilename: String) -> FileWrapper? {
+    /// Returns the file wrapper for an asset with the given filename.
+    ///
+    /// Looks up the asset by comparing against both ``FileWrapper/filename``
+    /// and ``FileWrapper/preferredFilename``.
+    ///
+    /// - Parameter filename: A bare filename such as `"photo.jpg"` (no path prefix).
+    /// - Returns: The matching ``FileWrapper``, or `nil` if no asset has that name.
+    @objc(assetFileWrapperNamed:) public func assetFileWrapper(named filename: String) -> FileWrapper? {
         for (_, fw) in self.assetsFileWrapper.fileWrappers ?? [:] {
-            if fw.filename == assetFilename || fw.preferredFilename == assetFilename {
+            if fw.filename == filename || fw.preferredFilename == filename {
                 return fw
             }
         }
-        
+
         return nil
     }
 
+    /// Removes an asset from the bundle.
+    ///
+    /// - Parameter fileWrapper: The ``FileWrapper`` to remove from the `assets/` directory.
+    @objc public func removeAssetFileWrapper(_ fileWrapper: FileWrapper) {
+        self.assetsFileWrapper.removeFileWrapper(fileWrapper)
+    }
+
     
-    /// Add a NSFileWrapper to the TextBundleWrapper's assetFileWrapper.
-    /// If a file have the same name of an exiting file the name will be updated to avoid conflicts.
-    /// With `preventAssetDuplication` set as `true` if the name and file content are the same this method does nothing.
-    /// - Parameter filewrapper:  A NSFileWrapper to add to the TextBundleWrapper's assets
-    /// - Returns: The updated filename of the added asset
+    /// Adds a file wrapper to the bundle's `assets/` directory.
+    ///
+    /// When a file with the same name already exists the incoming wrapper is
+    /// renamed to avoid collisions (e.g. `"image 2.png"`).
+    /// If ``preventAssetDuplication`` is `true` and an existing asset has both the
+    /// same name *and* identical contents, the addition is skipped and the
+    /// existing filename is returned.
+    ///
+    /// - Parameter filewrapper: The ``FileWrapper`` to add.
+    /// - Returns: The bare filename under which the asset was stored, or `nil`
+    ///   if the wrapper has no usable filename.
     @discardableResult
     @objc public func addAssetFileWrapper(_ filewrapper: FileWrapper) -> String? {
         guard let originalFilename = filewrapper.filename ?? filewrapper.preferredFilename,

--- a/TextBundleTests/TextBundleTests.m
+++ b/TextBundleTests/TextBundleTests.m
@@ -62,7 +62,7 @@
     NSError *e = nil;
     TextBundleWrapper *tb = [[TextBundleWrapper alloc] initWithUrl:fileURL options:NSFileWrapperReadingImmediate error:&e];
     
-    NSFileWrapper *assetWrapper = [tb fileWrapperFor:@"oh no.jpg"];
+    NSFileWrapper *assetWrapper = [tb assetFileWrapperNamed:@"oh no.jpg"];
     
     XCTAssertNil(e);
     XCTAssertEqual(tb.assetsFileWrapper.fileWrappers.count, 1);
@@ -183,12 +183,12 @@
     XCTAssertNil(e);
     XCTAssertEqual(tb.assetsFileWrapper.fileWrappers.count, 1);
 
-    XCTAssertNotNil([tb assetFileWrapperForFilePath:@"assets/oh no.jpg"]);
-    XCTAssertNotNil([tb assetFileWrapperForFilePath:@"./assets/oh no.jpg"]);
-    XCTAssertNil([tb assetFileWrapperForFilePath:@"oh no.jpg"], @"a path relative to the bundle is required");
-    XCTAssertNil([tb assetFileWrapperForFilePath:@"/tmp/bad/things/happen/oh no.jpg"], @"Non-existing path should not find the asset even though the filename matches");
-    XCTAssertNil([tb assetFileWrapperForFilePath:@"../sample asset.jpg"], @"Accessing files outside the bundle (relative to the bundle itself) should not work");
-    XCTAssertNil([tb assetFileWrapperForFilePath:@"../../sample asset.jpg"], @"Accessing files outside the bundle (relative to the ./asset/ subdir) should not work");
+    XCTAssertNotNil([tb assetFileWrapperAtPath:@"assets/oh no.jpg"]);
+    XCTAssertNotNil([tb assetFileWrapperAtPath:@"./assets/oh no.jpg"]);
+    XCTAssertNil([tb assetFileWrapperAtPath:@"oh no.jpg"], @"a path relative to the bundle is required");
+    XCTAssertNil([tb assetFileWrapperAtPath:@"/tmp/bad/things/happen/oh no.jpg"], @"Non-existing path should not find the asset even though the filename matches");
+    XCTAssertNil([tb assetFileWrapperAtPath:@"../sample asset.jpg"], @"Accessing files outside the bundle (relative to the bundle itself) should not work");
+    XCTAssertNil([tb assetFileWrapperAtPath:@"../../sample asset.jpg"], @"Accessing files outside the bundle (relative to the ./asset/ subdir) should not work");
 }
 
 

--- a/TextBundleTests/TextBundleTests.m
+++ b/TextBundleTests/TextBundleTests.m
@@ -191,6 +191,21 @@
     XCTAssertNil([tb assetFileWrapperAtPath:@"../../sample asset.jpg"], @"Accessing files outside the bundle (relative to the ./asset/ subdir) should not work");
 }
 
+- (void)testRemoveAsset
+{
+    NSURL *fileURL = [self textBundleURLForFilename:@"only text"];
+    TextBundleWrapper *tb = [[TextBundleWrapper alloc] initWithUrl:fileURL options:NSFileWrapperReadingImmediate error:nil];
+
+    NSURL *assetURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"sample asset" withExtension:@"jpg"];
+    NSFileWrapper *assetFW = [[NSFileWrapper alloc] initWithURL:assetURL options:0 error:nil];
+    [tb addAssetFileWrapper:assetFW];
+    XCTAssertEqual(tb.assetsFileWrapper.fileWrappers.count, 1);
+
+    [tb removeAssetFileWrapper:assetFW];
+    XCTAssertEqual(tb.assetsFileWrapper.fileWrappers.count, 0);
+    XCTAssertNil([tb assetFileWrapperNamed:@"sample asset.jpg"]);
+}
+
 
 #pragma mark - Metadata
 


### PR DESCRIPTION
The new assetFileWrapper function clarifies which file wrapper you
got, but the old fileWrapper(for:) was ambiguous.

This makes the asset-related function more similar:

- assetFileWrapper(atPath:) and assetFileWrapperAtPath
- assetFileWrapper(named:) and assetFileWrapperNamed: (instead of fileWrapper(for:))
- addAssetFileWrapper(_:) -- remains the same and fits the 'getters'